### PR TITLE
 change consumer callback implement

### DIFF
--- a/eventuate-tram-consumer-kafka/src/main/java/io/eventuate/tram/consumer/kafka/MessageConsumerKafkaImpl.java
+++ b/eventuate-tram-consumer-kafka/src/main/java/io/eventuate/tram/consumer/kafka/MessageConsumerKafkaImpl.java
@@ -50,14 +50,15 @@ public class MessageConsumerKafkaImpl implements MessageConsumer {
         try {
           logger.trace("Invoking handler {} {}", subscriberId, m.getId());
           handler.accept(m);
+          logger.trace("handled message {} {}", subscriberId, m.getId());
+          callback.accept(null, null);
         } catch (Throwable t) {
           logger.trace("Got exception {} {}", subscriberId, m.getId());
           logger.trace("Got exception ", t);
           callback.accept(null, t);
           return null;
         }
-        logger.trace("handled message {} {}", subscriberId, m.getId());
-        callback.accept(null, null);
+
         return null;
       });
     };


### PR DESCRIPTION
when the message subscriber catch exception, the callback method will be executed twice.  So even the message process failed, system still commit the offset. 