### PR TITLE
#7. Implement multi-threaded dispatcher so messages are not consumed …

### DIFF
--- a/eventuate-tram-consumer-kafka/build.gradle
+++ b/eventuate-tram-consumer-kafka/build.gradle
@@ -14,6 +14,7 @@ dependencies {
     compile "io.eventuate.client.java:eventuate-client-java-jdbc-common:$eventuateClientVersion"
 
     testCompile "org.springframework.boot:spring-boot-starter-test:$springBootVersion"
+    testCompile "io.eventuate.util:eventuate-util-test:$eventuateUtilVersion"
 }
 
 

--- a/eventuate-tram-consumer-kafka/src/main/java/io/eventuate/tram/consumer/kafka/SwimlaneDispatcher.java
+++ b/eventuate-tram-consumer-kafka/src/main/java/io/eventuate/tram/consumer/kafka/SwimlaneDispatcher.java
@@ -26,6 +26,10 @@ public class SwimlaneDispatcher {
     this.executor = executor;
   }
 
+  public boolean getRunning() {
+    return running.get();
+  }
+
   public void dispatch(Message message, Consumer<Message> messageConsumer) {
     synchronized (queue) {
       QueuedMessage queuedMessage = new QueuedMessage(message, messageConsumer);
@@ -61,6 +65,7 @@ public class SwimlaneDispatcher {
     else {
       logger.trace("Invoking handler for message for {} {} {}", subscriberId, swimlane, queuedMessage.message);
       queuedMessage.messageConsumer.accept(queuedMessage.message);
+      processNextQueuedMessage();
     }
   }
 

--- a/eventuate-tram-consumer-kafka/src/main/java/io/eventuate/tram/consumer/kafka/SwimlaneDispatcher.java
+++ b/eventuate-tram-consumer-kafka/src/main/java/io/eventuate/tram/consumer/kafka/SwimlaneDispatcher.java
@@ -59,13 +59,15 @@ public class SwimlaneDispatcher {
 
 
   public void processQueuedMessage() {
-    QueuedMessage queuedMessage = getNextMessage();
-    if (queuedMessage == null)
-      logger.trace("No queued message for {} {}", subscriberId, swimlane);
-    else {
-      logger.trace("Invoking handler for message for {} {} {}", subscriberId, swimlane, queuedMessage.message);
-      queuedMessage.messageConsumer.accept(queuedMessage.message);
-      processNextQueuedMessage();
+    while (true) {
+      QueuedMessage queuedMessage = getNextMessage();
+      if (queuedMessage == null) {
+        logger.trace("No queued message for {} {}", subscriberId, swimlane);
+        return;
+      } else {
+        logger.trace("Invoking handler for message for {} {} {}", subscriberId, swimlane, queuedMessage.message);
+        queuedMessage.messageConsumer.accept(queuedMessage.message);
+      }
     }
   }
 

--- a/eventuate-tram-consumer-kafka/src/test/java/io/eventuate/tram/consumer/kafka/SwimlaneDispatcherTest.java
+++ b/eventuate-tram-consumer-kafka/src/test/java/io/eventuate/tram/consumer/kafka/SwimlaneDispatcherTest.java
@@ -1,0 +1,56 @@
+package io.eventuate.tram.consumer.kafka;
+
+import io.eventuate.tram.messaging.common.Message;
+import io.eventuate.util.test.async.Eventually;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+
+public class SwimlaneDispatcherTest {
+
+  @Test
+  public void testProcessing() {
+    SwimlaneDispatcher swimlaneDispatcher = new SwimlaneDispatcher("1", 1, Executors.newCachedThreadPool());
+
+    AtomicInteger counter = new AtomicInteger(0);
+
+    Consumer<Message> handler = msg -> {
+      counter.incrementAndGet();
+      try {
+        Thread.sleep(50);
+      } catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      }
+    };
+
+    //test case when events supplied continuously, and processing is not stopping
+    for (int i = 0; i < 5; i++) {
+      if (i > 0) {
+        Assert.assertTrue(swimlaneDispatcher.getRunning());
+      }
+      swimlaneDispatcher.dispatch(null, handler);
+    }
+
+    Eventually.eventually(() -> {
+      Assert.assertEquals(5, counter.get());
+      Assert.assertFalse(swimlaneDispatcher.getRunning());
+    });
+
+
+    //test event processing after stop
+    for (int i = 0; i < 5; i++) {
+      if (i > 0) {
+        Assert.assertTrue(swimlaneDispatcher.getRunning());
+      }
+      swimlaneDispatcher.dispatch(null, handler);
+    }
+
+    Eventually.eventually(() -> {
+      Assert.assertEquals(10, counter.get());
+      Assert.assertFalse(swimlaneDispatcher.getRunning());
+    });
+  }
+}


### PR DESCRIPTION
…in the Kafka consumer thread. Fixing swimlane dispatcher.